### PR TITLE
Remove link to live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ To run this application locally, you'll need to:
 - Docker
 - Heroku
 
+<!--
 ## Live Site
 
-[Here's](https://pairyopet.herokuapp.com/) a link to our live app!
+[Here's](https://pairyopet.herokuapp.com/) a link to our live app! 
+-->
 
 ## Documentation
 


### PR DESCRIPTION
You guys have likely heard, but I just wanted to give a heads up that Heroku will stop offering their free tiers on Novermber 28th. As far as I can tell the cheapest plan through heroku to keep it live is about $10 / month. I'm guessing their are some other places we can host it for free out there, but I don't have the time right now to work on that. I'm planning to let the free tier just expire, so unfortunately https://pairyopet.herokuapp.com/ will no longer work in a few more days :cry:

I wanted to give you guys a heads up so you could update any links you have to that and maybe visit the site one more time before it goes down. It's been fun to have it up so long!

If anyone wanted to pay the $10 / month let me know, and I can help you get access.